### PR TITLE
Detect legacy firmware and strictly adhere to protocol for new firmware

### DIFF
--- a/sktp2wic.asm
+++ b/sktp2wic.asm
@@ -149,7 +149,7 @@ start:
     jsr $ffd2
 
     jsr welcomeScreen
-   
+    jsr detectLegacyFirmware   
     
     cld ; no decimal-flag wanted
 
@@ -1154,6 +1154,39 @@ setWicToSendDataToC64:
     sta $dd00 
     rts
     
+;--------------------------
+detectLegacyFirmware: 
+;--------------------------
+    lda #$01
+    sta legacyFirmware
+    jsr setWicToExpectDataFromC64
+    ldy #$00
+
+-   lda versionStringRequest,y
+    jsr write_byte
+    iny
+    cpy #$04
+    bne -
+
+    jsr setWicToSendDataToC64
+    jsr read_byte
+
+    jsr read_byte
+    jsr read_byte
+    
+    cmp #$0d
+    bne +
+    dec legacyFirmware
+
++   tay
+-   jsr read_byte
+    dey
+    bne -
+
+    rts
+
+versionStringRequest: !byte "W", $04, $00, $00
+legacyFirmware: !byte $01
 
 ;--------------------------
 requestDownloadURL:
@@ -1234,7 +1267,17 @@ urlprefix_string_next:
     jsr write_byte
     cpy cmd_default_server+1
     bne urlprefix_string_next
-    ;lda #13
+
+    lda legacyFirmware
+    beq +
+
+    jsr setWicToSendDataToC64
+    jsr read_byte
+
+    jsr read_byte
+    jsr read_byte
+
++   ;lda #13
     ;jsr $ffd2
     rts
 


### PR DESCRIPTION
There are certain commands in the legacy firmware implementation that do not send a response. The problem with these commands is that they don't even send a response header, which makes it impossible to write a generic client side library that does not need to know anything about the commands it sends and can thus handle all request/response sessions uniformly.

For this reason the new firmware always sends a response header and also expects the client to receive the response header after sending the command, regardless of whether or not the reponse happens to be is empty.

In this case the offending command is the SET_SERVER command issued by the sendURLPrefixToWic routine.

This commit adds a routine to detect the legacy firmware by testing if the response to GET_VERSION_STRING is exactly 13 bytes long and calls this routine during startup. If a legacy firmware is detected, the routine sendURLPrefixToWic behaves like before. If a new firmware is detected, the routine additionally receives the response header, as expected by the new firmware.

Without this fix, it is possible that the user proceeds from the welcome screen before the new firmware has aborted the SET_SERVER request after the transfer times out on the ESP side (expecting the receipt of the response header), and the initial handshakes send by the next request are misinterpreted. Since the sktp-client does not implement timeout detection, it gets stuck in an endless loop in this case.

So this commit makes sure that the sktp-client will continue to work with both the old and new firmware.